### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/add-blob.mjs
+++ b/scripts/add-blob.mjs
@@ -55,7 +55,7 @@ const file = args[1];
 
 		const cmp = keyToComponent(entry.key);
 
-		let source = entry.calls ? entry.calls.join('\n').substr(0, 512) : null;
+		let source = entry.calls ? entry.calls.join('\n').slice(0, 512) : null;
 		if ( source?.includes('MainMenu.getSettingsTree') )
 			source = 'FFZ Control Center';
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but as the change is trivial it doesn't hurt to switch.